### PR TITLE
Fix read method in Tag class

### DIFF
--- a/source/vmsn.py
+++ b/source/vmsn.py
@@ -68,7 +68,8 @@ class Tag():
         if size == -1:
             size = self.data_size - offset
         #print("base addr: {0:X}, paddr: {1:X}, size: {2:X}".format(self.data_offset, self.data_offset + offset, size))
-        return self.parser.read(self.data_offset + offset, size)
+        self.parser.seek(self.data_offset + offset)
+        return self.parser.read(size)
  
     def read_offset(self):
         if self.data_size < self.parser._offset_size:


### PR DESCRIPTION
self.parser.read() only takes the size as a parameter, so the following line caused the following Exception:
TypeError: read() takes exactly 2 arguments (3 given)

To fix it I first used self.parser.seek() to the given offset, and then used read with the given size